### PR TITLE
Revert "Add ignore-platform-reqs for PHP 8.0"

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -138,16 +138,13 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ["7.3", "7.4"]
+        php-version: ["7.3", "7.4", "8.0"]
         operating-system: ["ubuntu-latest"]
         composer-args: [ "" ]
         include:
           - php-version: "7.4"
             operating-system: "ubuntu-latest"
             composer-args: "--prefer-lowest"
-          - php-version: "8.0"
-            operating-system: "ubuntu-latest"
-            composer-args: "--ignore-platform-reqs" # TODO drop with roave-no-floaters PHP 8.0 support
           - php-version: "8.1"
             operating-system: "ubuntu-latest"
             composer-args: "--ignore-platform-reqs"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -138,7 +138,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ["7.3", "7.4", "8.0"]
+        php-version: ["7.4", "8.0"]
         operating-system: ["ubuntu-latest"]
         composer-args: [ "" ]
         include:

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
 		"phpstan/phpstan-deprecation-rules": "^0.12",
 		"phpstan/phpstan-strict-rules": "^0.12",
 		"thecodingmachine/phpstan-safe-rule": "^1",
-		"roave/no-floaters": "^1.1.0",
+		"roave/no-floaters": "^1.4.0",
 
 		"symplify/easy-coding-standard": "^9.2",
 


### PR DESCRIPTION
Requires Roave/no-floaters with PHP 8.0 support. (i.e. https://github.com/Roave/no-floaters/pull/20 to be merged)