### PR TITLE
Update README versions table for v0.6.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ composer require jan-made/mail-chimp
 
 ## Versions
 
-| State  | Version | Branch   | PHP        |
-|--------|---------|----------|------------|
-| dev    | `^0.7`  | `master` | `8.1, 8.2` |
-| stable | `^0.6`  | `master` | `>= 7.3`   |
-| stable | `^0.5`  | `master` | `>= 7.3`   |
-| stable | `^0.4`  | `master` | `>= 7.2`   |
-| stable | `^0.3`  | `master` | `>= 7.2`   |
-| stable | `^0.2`  | `master` | `>= 7.1`   |
+| State  | Version | Branch   | PHP                          |
+|--------|---------|----------|------------------------------|
+| dev    | `^0.7`  | `master` | `^8.2 \|\| ^8.3 \|\| ^8.4`  |
+| stable | `^0.6`  | `master` | `^8.2 \|\| ^8.3 \|\| ^8.4`  |
+| stable | `^0.5`  | `master` | `>= 7.3`                    |
+| stable | `^0.4`  | `master` | `>= 7.2`                    |
+| stable | `^0.3`  | `master` | `>= 7.2`                    |
+| stable | `^0.2`  | `master` | `>= 7.1`                    |
 
 
 ## Documentation


### PR DESCRIPTION
## Summary

- Update PHP version requirements in README versions table to reflect actual `composer.json` constraints (`^8.2 || ^8.3 || ^8.4`) for dev `^0.7` and stable `^0.6`

The composer dev alias (`v0.7.x-dev`) is already correct for post-v0.6.0 development — no change needed there.